### PR TITLE
Add auto-assign reviewer workflow

### DIFF
--- a/.github/auto-assign-config.yml
+++ b/.github/auto-assign-config.yml
@@ -1,0 +1,26 @@
+# Set to true to add reviewers to pull requests
+addReviewers: true
+
+# Set to true to add assignees to pull requests
+addAssignees: true
+
+# A list of reviewers to be added to pull requests (GitHub user name)
+reviewers:
+  - thomasvincent
+
+# A number of reviewers added to the pull request
+# Set 0 to add all the reviewers (default: 0)
+numberOfReviewers: 1
+
+# A list of assignees, overrides reviewers if set
+assignees:
+  - thomasvincent
+
+# A number of assignees to add to the pull request
+# Set to 0 to add all of the assignees.
+# Uses numberOfReviewers if unset.
+numberOfAssignees: 1
+
+# A list of keywords to be skipped the process that add reviewers if pull requests include it
+# skipKeywords:
+#   - wip

--- a/.github/workflows/auto-assign-reviewer.yml
+++ b/.github/workflows/auto-assign-reviewer.yml
@@ -1,0 +1,14 @@
+name: Auto Assign Reviewer
+
+on:
+  pull_request:
+    types: [opened, ready_for_review, reopened]
+
+jobs:
+  auto-assign:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Auto-assign reviewer
+        uses: kentaro-m/auto-assign-action@v1.2.5
+        with:
+          configuration-path: .github/auto-assign-config.yml


### PR DESCRIPTION
This PR adds a GitHub Actions workflow that automatically assigns thomasvincent as a reviewer to all pull requests.

This ensures that you are always notified of new PRs and can review them, even if they are created by other contributors or by yourself.

The workflow uses the [auto-assign-action](https://github.com/kentaro-m/auto-assign-action) to automatically assign reviewers and assignees to pull requests.